### PR TITLE
[EXPRESS] enhance emitter with file upload

### DIFF
--- a/express_emitter/models.py
+++ b/express_emitter/models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+
+class FileRecord(BaseModel):
+    """Database representation of an uploaded file."""
+
+    filename: str
+    source: str
+    content: str
+    timestamp: datetime
+    meta: Dict[str, Any]

--- a/express_emitter/requirements.txt
+++ b/express_emitter/requirements.txt
@@ -4,3 +4,7 @@ sentence-transformers
 redis[hiredis]
 loguru
 prometheus-fastapi-instrumentator
+httpx
+psycopg2-binary
+python-multipart
+PyMuPDF

--- a/express_emitter/tests/test_utils.py
+++ b/express_emitter/tests/test_utils.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from io import BytesIO
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+import pytest
+
+from express_emitter.utils import determine_source, extract_content
+
+
+def test_determine_source() -> None:
+    assert determine_source(".txt") == "text"
+    assert determine_source(".csv") == "csv"
+    assert determine_source(".pdf") == "pdf"
+    assert determine_source(".foo") == "unknown"
+
+
+def test_extract_text() -> None:
+    data = b"hello world"
+    assert extract_content(data, ".txt") == "hello world"
+    assert "a,b" in extract_content(b"a,b\n1,2", ".csv")
+
+
+def test_extract_pdf(tmp_path: str) -> None:
+    pytest.importorskip("fitz")
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "hello pdf")
+    pdf_bytes = doc.write()
+    doc.close()
+
+    text = extract_content(pdf_bytes, ".pdf")
+    assert "hello pdf" in text

--- a/express_emitter/utils.py
+++ b/express_emitter/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+ALLOWED_EXTENSIONS = {".txt", ".csv", ".pdf"}
+
+
+def determine_source(extension: str) -> str:
+    """Map file extension to source type."""
+    ext = extension.lower()
+    mapping = {".txt": "text", ".csv": "csv", ".pdf": "pdf"}
+    return mapping.get(ext, "unknown")
+
+
+def extract_content(content: bytes, extension: str) -> str:
+    """Return text content from supported file bytes."""
+    ext = extension.lower()
+    if ext in {".txt", ".csv"}:
+        return content.decode("utf-8", errors="ignore")
+    if ext == ".pdf":
+        try:
+            import fitz  # PyMuPDF
+        except Exception as exc:  # noqa: BLE001
+            raise ImportError("PyMuPDF is required for PDF extraction") from exc
+
+        with fitz.open(stream=content, filetype="pdf") as doc:
+            text = "".join(page.get_text() for page in doc)
+        return text
+    raise ValueError("Unsupported file type")


### PR DESCRIPTION
## Summary
- extend `express_emitter` with file upload endpoint and DB persistence
- handle `.txt`, `.csv` and `.pdf` extraction using new utils
- forward uploaded content to interpret-service with metadata
- integrate DB check in health endpoint
- remove deprecated `express_service`

## Testing
- `pytest express_emitter/tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f81e88808332b1c6dff6115b0ece