### PR TITLE
[INTERPRET] Add well doc pipeline

### DIFF
--- a/interpret_service/requirements.txt
+++ b/interpret_service/requirements.txt
@@ -7,3 +7,5 @@ uvicorn[standard]
 loguru
 prometheus-fastapi-instrumentator
 prometheus-client
+openai
+qdrant-client

--- a/interpret_service/schemas.py
+++ b/interpret_service/schemas.py
@@ -12,3 +12,27 @@ class PruneResponse(BaseModel):
     pruned_embedding: List[float]
     timestamp: datetime
     details: dict
+
+class InterpretMeta(BaseModel):
+    field: str
+    district: str
+    operator: str
+    document_type: str
+
+
+class InterpretRequest(BaseModel):
+    filename: str
+    content: str
+    well_id: str
+    meta: InterpretMeta
+
+
+class InterpretResponse(BaseModel):
+    well_id: str
+    filename: str
+    summary: str
+    tags: List[str]
+    embedding: List[float]
+    pruned_content: str
+    meta: InterpretMeta
+    timestamp: datetime

--- a/interpret_service/tests/test_utils.py
+++ b/interpret_service/tests/test_utils.py
@@ -1,0 +1,82 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+import types
+import pytest
+
+# Stub openai and spacy to avoid import errors
+sys.modules['openai'] = types.SimpleNamespace(
+    ChatCompletion=types.SimpleNamespace(create=lambda **kwargs: None),
+    Embedding=types.SimpleNamespace(create=lambda **kwargs: {'data': [{'embedding': [0.0]*1536}]}),
+)
+
+class DummyDoc:
+    def __init__(self) -> None:
+        self.noun_chunks = [types.SimpleNamespace(text="pressure valve")]
+
+
+class DummyNLP:
+    def __call__(self, text: str) -> DummyDoc:  # type: ignore[override]
+        return DummyDoc()
+
+
+sys.modules['spacy'] = types.SimpleNamespace(load=lambda name: DummyNLP())
+
+from interpret_service.utils import extract_tags, prune_content
+
+
+def test_extract_tags() -> None:
+    text = "Operator adjusted pressure valve in district 5"
+    tags = extract_tags(text)
+    assert "pressure valve" in tags
+
+
+def test_prune_content() -> None:
+    text = "Line 1\nPressure reading 35 psi\nRandom\nOperator action"
+    pruned = prune_content(text)
+    assert "Pressure reading" in pruned
+    assert "Operator action" in pruned
+
+
+def test_interpret_endpoint(monkeypatch) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    from interpret_service.main import app
+
+    # Patch OpenAI helpers
+    monkeypatch.setattr(
+        "interpret_service.utils.summarize", lambda text: "summary"
+    )
+    monkeypatch.setattr(
+        "interpret_service.utils.get_embedding", lambda text: [0.0] * 1536
+    )
+
+    def mock_insert(collection, vector, metadata):
+        assert collection == "well_docs"
+        assert len(vector) == 1536
+    monkeypatch.setattr(
+        "shared.qdrant_client.insert_embedding_with_stage", mock_insert
+    )
+
+    client = TestClient(app)
+    payload = {
+        "filename": "test.txt",
+        "content": "Pressure log line",
+        "well_id": "W1",
+        "meta": {
+            "field": "A",
+            "district": "B",
+            "operator": "Op",
+            "document_type": "type",
+        },
+    }
+    resp = client.post("/interpret", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["well_id"] == "W1"
+    assert len(data["embedding"]) == 1536
+
+

--- a/interpret_service/utils.py
+++ b/interpret_service/utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import List
+import os
+import openai
+import spacy
+
+# Load spaCy model only once
+NLP = spacy.load("en_core_web_sm")
+
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+
+
+def summarize(text: str) -> str:
+    """Return a short summary of the text using OpenAI."""
+    prompt = (
+        "Summarize the following well document in two sentences:"\
+    )
+    response = openai.ChatCompletion.create(
+        model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+        messages=[{"role": "user", "content": f"{prompt}\n{text}"}],
+        temperature=0.3,
+    )
+    return response.choices[0].message["content"].strip()
+
+
+def extract_tags(text: str) -> List[str]:
+    """Extract key noun phrases from text."""
+    doc = NLP(text)
+    return list({chunk.text.lower() for chunk in doc.noun_chunks})
+
+
+def prune_content(text: str) -> str:
+    """Return lines likely containing operational data."""
+    relevant = []
+    for line in text.splitlines():
+        lower = line.lower()
+        if any(
+            kw in lower
+            for kw in ["pressure", "log", "event", "operator", "flow", "reading"]
+        ) or any(char.isdigit() for char in line):
+            relevant.append(line)
+    return "\n".join(relevant)
+
+
+def get_embedding(text: str) -> List[float]:
+    """Generate an embedding using OpenAI."""
+    resp = openai.Embedding.create(
+        input=text,
+        model=os.getenv("EMBED_MODEL", "text-embedding-ada-002"),
+    )
+    vector = resp["data"][0]["embedding"]
+    if len(vector) != 1536:
+        raise ValueError("Unexpected embedding size")
+    return vector

--- a/shared/qdrant_client.py
+++ b/shared/qdrant_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Dict, List
+
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import PointStruct, VectorParams, Distance
+
+QDRANT_HOST = os.getenv("QDRANT_HOST", "qdrant")
+QDRANT_PORT = int(os.getenv("QDRANT_PORT", 6333))
+
+_client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+def _ensure_collection(collection: str, dim: int) -> None:
+    collections = [c.name for c in _client.get_collections().collections]
+    if collection not in collections:
+        _client.recreate_collection(
+            collection_name=collection,
+            vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+        )
+
+
+def insert_embedding_with_stage(
+    collection: str, vector: List[float], metadata: Dict[str, Any]
+) -> None:
+    """Insert embedding with metadata into Qdrant."""
+    _ensure_collection(collection, len(vector))
+    point_id = str(uuid.uuid4())
+    _client.upsert(
+        collection_name=collection,
+        points=[PointStruct(id=point_id, vector=vector, payload=metadata)],
+    )


### PR DESCRIPTION
## Summary
- integrate OpenAI summarization, tag extraction, pruning and embeddings
- push embeddings to Qdrant with new shared client helper
- expose `/interpret` endpoint for well docs
- provide unit tests for new utils and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684853cc439483329646ff7f5693b38b