### PR TITLE
[VIEW] Add well-portal Next.js dashboard

### DIFF
--- a/well-portal/__tests__/api.test.ts
+++ b/well-portal/__tests__/api.test.ts
@@ -1,0 +1,29 @@
+import { fetchSpiral, queryWell, searchDocs, fetchOverview } from '../lib/api';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ ok: true }) })
+  ) as jest.Mock;
+});
+
+describe('api helpers', () => {
+  it('fetchSpiral posts to /spiral', async () => {
+    await fetchSpiral('WELL-001');
+    expect(fetch).toHaveBeenCalledWith('/spiral', expect.any(Object));
+  });
+
+  it('queryWell posts to /query', async () => {
+    await queryWell('WELL-001', 'hi');
+    expect(fetch).toHaveBeenCalledWith('/query', expect.any(Object));
+  });
+
+  it('searchDocs posts to /docs/search', async () => {
+    await searchDocs('WELL-001', 'test', 'literal');
+    expect(fetch).toHaveBeenCalledWith('/docs/search', expect.any(Object));
+  });
+
+  it('fetchOverview fetches /well/overview', async () => {
+    await fetchOverview('WELL-001');
+    expect(fetch).toHaveBeenCalledWith('/well/overview?well_id=WELL-001');
+  });
+});

--- a/well-portal/__tests__/components.test.tsx
+++ b/well-portal/__tests__/components.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from '@testing-library/react';
+import Home from '../pages/index';
+
+describe('Home page', () => {
+  it('renders title', () => {
+    const { getByText } = render(<Home />);
+    expect(getByText('Show Me the Well')).toBeInTheDocument();
+  });
+});

--- a/well-portal/components/DocumentSearch.tsx
+++ b/well-portal/components/DocumentSearch.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { searchDocs } from '../lib/api';
+
+interface Props {
+  wellId: string;
+}
+
+export default function DocumentSearch({ wellId }: Props) {
+  const [mode, setMode] = useState<'literal' | 'semantic'>('literal');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+
+  const search = async () => {
+    const res = await searchDocs(wellId, query, mode);
+    setResults(res.results || []);
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+      <h2 className="font-semibold mb-2">Document Search</h2>
+      <div className="flex gap-2 mb-2">
+        <input
+          className="flex-1 border rounded px-2"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search documents"
+        />
+        <select
+          className="border rounded"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as 'literal' | 'semantic')}
+        >
+          <option value="literal">Literal</option>
+          <option value="semantic">Semantic</option>
+        </select>
+        <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={search}>
+          Search
+        </button>
+      </div>
+      <ul className="space-y-1 text-sm max-h-40 overflow-auto">
+        {results.map((r, idx) => (
+          <li key={idx} className="border-b pb-1">
+            <p>{r.snippet}</p>
+            <p className="text-xs text-gray-500">{r.date}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/well-portal/components/SpiralView.tsx
+++ b/well-portal/components/SpiralView.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { fetchSpiral } from '../lib/api';
+
+type Point = {
+  timestamp: string;
+  gravity_score: number;
+};
+
+interface Props {
+  wellId: string;
+}
+
+export default function SpiralView({ wellId }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    async function draw() {
+      const data = await fetchSpiral(wellId);
+      const ctx = canvasRef.current?.getContext('2d');
+      if (!ctx) return;
+      ctx.clearRect(0, 0, 300, 300);
+      // placeholder spiral rendering
+      (data.points as Point[]).forEach((p, i) => {
+        const angle = i * 0.3;
+        const radius = i * 2;
+        const x = 150 + radius * Math.cos(angle);
+        const y = 150 + radius * Math.sin(angle);
+        ctx.beginPath();
+        ctx.arc(x, y, p.gravity_score, 0, Math.PI * 2);
+        ctx.fillStyle = '#3b82f6';
+        ctx.fill();
+      });
+    }
+    draw();
+  }, [wellId]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+      <h2 className="font-semibold mb-2">SCADA Spiral View</h2>
+      <canvas ref={canvasRef} width={300} height={300} />
+    </div>
+  );
+}

--- a/well-portal/components/WellChat.tsx
+++ b/well-portal/components/WellChat.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { queryWell } from '../lib/api';
+
+interface Props {
+  wellId: string;
+}
+
+export default function WellChat({ wellId }: Props) {
+  const [messages, setMessages] = useState<{ text: string; from: 'user' | 'bot' }[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const userMsg = { text: input, from: 'user' as const };
+    setMessages((m) => [...m, userMsg]);
+    setInput('');
+    const res = await queryWell(wellId, userMsg.text);
+    setMessages((m) => [...m, { text: res.answer || 'No answer', from: 'bot' }]);
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow h-80 flex flex-col">
+      <h2 className="font-semibold mb-2">Talk to the Well</h2>
+      <div className="flex-1 overflow-auto space-y-2 mb-2">
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.from === 'user' ? 'text-right' : ''}>
+            <span className="inline-block px-2 py-1 rounded bg-blue-100 dark:bg-blue-900">
+              {m.text}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border rounded px-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask a question"
+        />
+        <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/well-portal/components/WellOverview.tsx
+++ b/well-portal/components/WellOverview.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { fetchOverview } from '../lib/api';
+
+interface Props {
+  wellId: string;
+}
+
+interface OverviewData {
+  production: number[];
+  uptime: number;
+  downtime: number;
+  operator: string;
+  district: string;
+  field: string;
+  tags: string[];
+  reflection: string;
+}
+
+export default function WellOverview({ wellId }: Props) {
+  const [data, setData] = useState<OverviewData | null>(null);
+
+  useEffect(() => {
+    fetchOverview(wellId).then(setData);
+  }, [wellId]);
+
+  if (!data) return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">Loading...</div>
+  );
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+      <h2 className="font-semibold mb-2">Well Overview</h2>
+      <div className="mb-2">
+        <p className="text-sm">Operator: {data.operator}</p>
+        <p className="text-sm">District: {data.district}</p>
+        <p className="text-sm">Field: {data.field}</p>
+      </div>
+      <div className="mb-2">
+        <p className="text-sm">Uptime: {data.uptime}%</p>
+        <p className="text-sm">Downtime: {data.downtime}%</p>
+      </div>
+      <div className="mb-2">
+        <p className="text-sm font-semibold">Top Tags</p>
+        <ul className="list-disc pl-5 text-sm">
+          {data.tags.map((t) => (
+            <li key={t}>{t}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <p className="text-sm font-semibold">Most Recent Reflection</p>
+        <p className="text-sm">{data.reflection}</p>
+      </div>
+    </div>
+  );
+}

--- a/well-portal/jest.config.js
+++ b/well-portal/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+};

--- a/well-portal/lib/api.ts
+++ b/well-portal/lib/api.ts
@@ -1,0 +1,31 @@
+export async function fetchSpiral(wellId: string) {
+  const res = await fetch('/spiral', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target: 'well_id', value: wellId, stage: 'reflect' }),
+  });
+  return res.json();
+}
+
+export async function queryWell(wellId: string, query: string) {
+  const res = await fetch('/query', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ well_id: wellId, query }),
+  });
+  return res.json();
+}
+
+export async function searchDocs(wellId: string, query: string, mode: 'literal' | 'semantic') {
+  const res = await fetch('/docs/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ well_id: wellId, query, mode }),
+  });
+  return res.json();
+}
+
+export async function fetchOverview(wellId: string) {
+  const res = await fetch(`/well/overview?well_id=${wellId}`);
+  return res.json();
+}

--- a/well-portal/next-env.d.ts
+++ b/well-portal/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/well-portal/next.config.js
+++ b/well-portal/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/well-portal/package.json
+++ b/well-portal/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "well-portal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "ts-jest": "^29.0.0"
+  }
+}

--- a/well-portal/pages/_app.tsx
+++ b/well-portal/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/well-portal/pages/index.tsx
+++ b/well-portal/pages/index.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head';
+import SpiralView from '../components/SpiralView';
+import WellChat from '../components/WellChat';
+import DocumentSearch from '../components/DocumentSearch';
+import WellOverview from '../components/WellOverview';
+
+export default function Home() {
+  return (
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4">
+      <Head>
+        <title>Show Me the Well</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Show Me the Well</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-4">
+          <SpiralView wellId="WELL-001" />
+          <DocumentSearch wellId="WELL-001" />
+        </div>
+        <div className="space-y-4">
+          <WellChat wellId="WELL-001" />
+          <WellOverview wellId="WELL-001" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/well-portal/postcss.config.js
+++ b/well-portal/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/well-portal/styles/globals.css
+++ b/well-portal/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/well-portal/tailwind.config.js
+++ b/well-portal/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/well-portal/tsconfig.json
+++ b/well-portal/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build a new Next.js 13 dashboard in `well-portal`
- add React components for SCADA spiral view, well chat, document search and overview
- include API helper functions and unit tests
- configure Tailwind, Jest and TypeScript

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849839c51088332b6e9ae0264ffbb66